### PR TITLE
feat(workflow): remove 3rd party action

### DIFF
--- a/.github/workflows/deploy-workflow.yaml
+++ b/.github/workflows/deploy-workflow.yaml
@@ -73,18 +73,39 @@ jobs:
 
         - name: Deploy image to K8 cloud-platform-go-get-module (${{ inputs.env }}) namespace
           id: deploy-image
-          uses: vimeda/helm@8fb24318e538359380b6acaaee9aa686d5f0c5cb # v1.7.0
-          with:
-            release: go-get-module
-            namespace: ${{ secrets.kube_namespace }}
-            chart: deploy
-            values: |
-              ecrUrl: ${{ secrets.ecr_url }}
-              imageTag: ${{ inputs.image_tag }}
-              cluster: ${{ steps.set-cluster.outputs.CLUSTER }}
-              ingressIdentifier: api-${{ secrets.kube_namespace }}-${{ steps.set-cluster.outputs.INGRESS_COLOUR }}
-              namespace: ${{ secrets.kube_namespace }}
+          shell: bash
           env:
             KUBECONFIG_FILE: ${{ env.FLAT_KUBE_CONFIG }}
+            ECR_URL: ${{ secrets.ecr_url }}
+            IMAGE_TAG: ${{ inputs.image_tag }}
+            CLUSTER: ${{ steps.set-cluster.outputs.CLUSTER }}
+            INGRESS_IDENTIFIER: ${{ steps.set-cluster.outputs.INGRESS_IDENTIFIER }}
+            NAMESPACE: ${{ steps.set-cluster.outputs.NAMESPACE }}
+          run: |
+            KUBECONFIG_TEMP=$(mktemp)
+            echo "$KUBECONFIG_FILE" > "$KUBECONFIG_TEMP"
+            export KUBECONFIG="$KUBECONFIG_TEMP"
 
+            VALUES_TEMP=$(mktemp --suffix=.yaml)
+            cat > "$VALUES_TEMP" << EOF
+            ecrUrl: "${ECR_URL}"
+            imageTag: "${IMAGE_TAG}"
+            cluster: "${CLUSTER}"
+            ingressIdentifier: "${INGRESS_IDENTIFIER}"
+            namespace: "${NAMESPACE}"
+            securityContext:
+              allowPrivilegeEscalation: false
+              seccompProfile:
+                type: RuntimeDefault
+              capabilities:
+                drop:
+                  - ALL
+              runAsNonRoot: true
+            EOF
+
+            helm upgrade --install go-get-module deploy \ 
+              --namespace "${NAMESPACE}" \
+              --values "$VALUES_TEMP"
+            
+            rm "$KUBECONFIG_TEMP" "$VALUES_TEMP"
 


### PR DESCRIPTION
vimeda/helm is used for deploying the app to the cluster, instead of using this we are replacing with a shell script in the action that will do the same thing
